### PR TITLE
fallback for missing host header

### DIFF
--- a/src/xraysink/asgi/middleware.py
+++ b/src/xraysink/asgi/middleware.py
@@ -43,11 +43,11 @@ async def xray_middleware(request, handler):
 
     # Get name of service or generate a dynamic one from host
     name = calculate_segment_name(
-        request.headers["host"].split(":", 1)[0], xray_recorder
+        request.headers.get("host", "localhost").split(":", 1)[0], xray_recorder
     )
 
     sampling_req = {
-        "host": request.headers["host"],
+        "host": request.headers.get("host", "localhost"),
         "method": request.method,
         "path": _get_request_path(request),
         "service": name,

--- a/tests/asgi/middleware/test_middleware.py
+++ b/tests/asgi/middleware/test_middleware.py
@@ -141,11 +141,11 @@ class TestRequestHandler:
         xray_header = server_response.headers[http.XRAY_HEADER]
         assert expected_root in xray_header
 
-    async def test_should_with_missing_http_host_header(self, client, recorder):
+    async def test_should_fallback_to_localhost_when_missing_http_host_header(
+        self, client, recorder
+    ):
         if "aiohttp" in type(client).__module__:
-            pytest.skip(
-                "aiohttp doesn't have the issue with missing host headers"
-            )
+            pytest.skip("aiohttp doesn't have the issue with missing host headers")
 
         del client.headers["host"]
 


### PR DESCRIPTION
In some scenarios (e.g. health check of lambda function behind ALB/multi target group), there is no host headed provided. It seems that with the fastapi integration, this breaks execution of this library. I added a fallback, which in the best case would be configurable later.


relates to https://github.com/garyd203/xraysink/issues/65