### PR TITLE
Update transitive `certifi` dependency to resolve security issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.7.0 (unreleased)
 
+Security:
+* Upgrade `certifi` to v2023.7.22 to resolve security vulnerability with the e-Tugra root
+  SSL certificate (https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/C-HrP1SEq1A
+  has further details)
+
 Changed:
 * Test against `aws_xray_sdk` release up to v2.12.0
 * Test functionality in `AsyncContext` in `aws_xray_sdk`, including fix in v2.10.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -299,13 +299,13 @@ crt = ["awscrt (==0.16.9)"]
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]


### PR DESCRIPTION
See https://github.com/garyd203/xraysink/security/dependabot/16 and https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/C-HrP1SEq1A